### PR TITLE
Update random delay behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## UNRELEASED
+
+* Fix random delay string conversion check
+* Change random delay shell to bash as cron runs with /bin/sh and they are not
+* Make random delay command link a `;` as with `&&` may prevent the job from
+  running if sleep with bad input (or for any reason) fails.
+
 ## v0.0.1
 
 * Fix random delay to not run sleep when value is 0

--- a/cron/jobs.sls
+++ b/cron/jobs.sls
@@ -12,7 +12,7 @@
 {% set log = job_config.get('log', cron_defaults.default_log) %}
 {% set disabled = job_config.get('disabled', cron_defaults.default_disabled) %}
 {% set cmd =  "" %}
-{% if random_delay != '0' %}{% set cmd = cmd  +  " echo $(date -u) INFO: Entering random sleep phase... >> " + log + " 2>&1 && sleep $(expr $RANDOM \% " ~ random_delay + ") && " %}{% endif %}
+{% if random_delay|string != '0' %}{% set cmd = cmd  +  " echo $(date -u) INFO: Entering random sleep phase... >> " + log + " 2>&1 && /bin/bash -c \"sleep \$(expr \$RANDOM \% " ~ random_delay + ") \"; " %}{% endif %}
 {% if one_instance %}{% set cmd = cmd  +  " /usr/bin/python /srv/salt-formulas/_modules/asg.py && " %}{% endif %}
 {% set cmd = cmd +  " " + name + " " + " >> " + log + " 2>&1 " %}
 {% if disabled %}


### PR DESCRIPTION
* Fix random delay string conversion check
* Change random delay shell to bash as cron runs with /bin/sh and it doesn't have $RANDOM variable
* Make random delay command link a `;` as with `&&` may prevent the job from
  running if sleep with bad input (or for any reason) fails.