### PR TITLE
by default, print result to stdout and log file

### DIFF
--- a/cron/jobs.sls
+++ b/cron/jobs.sls
@@ -14,7 +14,7 @@
 {% set cmd =  "" %}
 {% if random_delay|string != '0' %}{% set cmd = cmd  +  " echo $(date -u) INFO: Entering random sleep phase... >> " + log + " 2>&1 && /bin/bash -c \"sleep \$(expr \$RANDOM \% " ~ random_delay + ") \"; " %}{% endif %}
 {% if one_instance %}{% set cmd = cmd  +  " /usr/bin/python /srv/salt-formulas/_modules/asg.py && " %}{% endif %}
-{% set cmd = cmd +  " " + name + " " + " >> " + log + " 2>&1 " %}
+{% set cmd = cmd +  " " + name + " " + "2>&1 | tee -a " + log %}
 {% if disabled %}
 cron_job_{{job_id}}:
   cron.absent:


### PR DESCRIPTION
Print output to screen and cron.log by default
```
root@i-072fb729e75ca0db3:~# crontab -l
# Lines below here are managed by Salt, do not edit
# This is a test job SALT_CRON_IDENTIFIER:test_cron_job
*/1 * * * * /usr/bin/python /srv/salt-formulas/_modules/asg.py && ls -al 2>&1 | tee -a /var/log/cron.log
```